### PR TITLE
Add postinstall

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: build
-VERSION=$(shell node -e "process.stdout.write(require('./package.json').version)")
+VERSION=$(shell node -e "process.stdout.write(require('./package.json').version)" | sed 's/-.*//')
 SRC_DIR=easyXDM/src
 
 build: lib/easyXDM.js lib/easyXDM.debug.js

--- a/package.json
+++ b/package.json
@@ -1,8 +1,11 @@
 {
   "name": "easyxdm",
-  "version": "2.4.19-pre.2",
+  "version": "2.4.19-pre.3",
   "description": "",
   "main": "lib/easyXDM.js",
+  "scripts": {
+    "postinstall": "make"
+  },
   "homepage": "",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR fixes a bug where the "-pre.XX" version suffix caused make to fail when run naively. It also adds the make command to postinstall so you can have it run automatically when using it as a dependency.
